### PR TITLE
Drop Ruby 1.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
-  - jruby-18mode
+  - 2.0.0
   - jruby-19mode
-  - rbx-18mode
   - rbx-19mode
-

--- a/test/domino_test.rb
+++ b/test/domino_test.rb
@@ -123,6 +123,6 @@ class DominoTest < MiniTest::Unit::TestCase
   end
 
   def test_attributes
-    assert_equal({:name => 'Alice', :biography => 'Alice is fun', :favorite_color => 'Blue'}, Dom::Person.first.attributes)
+    assert_equal({name: 'Alice', biography: 'Alice is fun', favorite_color: 'Blue'}, Dom::Person.first.attributes)
   end
 end


### PR DESCRIPTION
Capybara 2.0 dropped 1.8 support, so Domino probably should also.
