### PR TITLE
Use `unless` instead of `if`

### DIFF
--- a/lib/domino.rb
+++ b/lib/domino.rb
@@ -118,7 +118,7 @@ class Domino
 
     # Return capybara nodes for this object
     def nodes
-      unless  @selector
+      unless @selector
         raise Domino::Error.new("You must define a selector")
       end
       Capybara.current_session.all(@selector)


### PR DESCRIPTION
It's generally better to use `unless` with a positive check (such as if it exists) then `if` with a negative check (such as if it is `nil`).
