### PR TITLE
add Domino.find! method which waits for matching node

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ access to the capybara node.
 
 For more information about using Capybara nodes, check [Capybara Documentation](https://github.com/jnicklas/capybara/blob/master/README.rdoc).
 
+## Dealing with Asynchronous Behavior
+
+When working with Capybara drivers that support JavaScript, it may be
+necessary to wait for elements to appear. Note that the following code
+simply collects all `Account` dominos currently on the page and
+returns the first:
+
+    Dom::Account.first # returns nil if account is displayed asynchronously
+
+When you are waiting for a unique domino to appear, you can instead
+use the `find!` method:
+
+    Dom::Account.find! # waits for matching element to appear
+
+If no matching element appears, Capybara will raise an error telling
+you about the expected selector.  Depending on the
+[`Capybara.match` option](https://github.com/jnicklas/capybara#strategy),
+this will also raise an error if the selector matches multiple nodes.
 
 ## Integration with Cucumber
 

--- a/lib/domino.rb
+++ b/lib/domino.rb
@@ -59,6 +59,18 @@ class Domino
       map{|node| node}
     end
 
+    # Returns Domino for capybara node matching selector.
+    #
+    # Raises an error if no matching node is found. For drivers that
+    # support asynchronous behavior, this method waits for a matching
+    # node to appear.
+    def find!
+      if @selector.nil?
+        raise Domino::Error.new("You must define a selector")
+      end
+      new(Capybara.current_session.find(@selector))
+    end
+
     # Define the selector for this Domino
     #
     #   module Dom

--- a/test/domino_test.rb
+++ b/test/domino_test.rb
@@ -143,4 +143,20 @@ class DominoTest < MiniTest::Unit::TestCase
   def test_callback
     assert_equal 23, Dom::Person.find_by_name("Alice").age
   end
+
+  def test_find_bang
+    assert_equal '#receipt-72', Dom::Receipt.find!.id
+  end
+
+  def test_find_bang_without_match
+    assert_raises Capybara::ElementNotFound do
+      Dom::Animal.find!
+    end
+  end
+
+  def test_find_bang_without_selector
+    assert_raises Domino::Error do
+      Dom::NoSelector.find!
+    end
+  end
 end


### PR DESCRIPTION
When working with asynchronous Capybara drivers, it may be necessary
to wait for dominos to appear eventually. The `find!` method uses
Capybara's `find` instead of `all` to wait for asynchronously created
nodes.

Capybara raises informative error messages if no match is found. This
prevents hard to debug "undefined method of nil" errors when trying to
interact with an expected unique Domino on the page.
- Added Domino.find!
- Added tests for matching, non-matching and missing selector cases
- Added section to README discussing usage with JS enabled Capybara
  drivers

Regarding test suite speed: The default Capybara driver does not support 
waiting. So the test which tries to find a non-existing node does not lag.
