### PR TITLE
Add support for finding node by multiple attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Now in your integration test you can use some of Domino's methods:
 assert_equal 4, Dom::Post.count
 refute_nil Dom::Post.find_by_title('First Post')
 
-# Multiple attributes
+# Multiple attributes, returns first match if any
 refute_nil Dom::Post.find_by(title: 'First Post', author: 'Jane Doe')
 
 # Multiple attributes with exception if no match is found
 refute_nil Dom::Post.find_by!(title: 'First Post', author: 'Jane Doe')
+
+# Multiple attributes, returns all matches if any
+assert_equal ["12/06/2014", "12/01/2014"], Dom::Post.where(author: 'Jane Doe').map(&:posted_on)
 ```
 
 What makes it really powerful is defining scoped actions:

--- a/lib/domino.rb
+++ b/lib/domino.rb
@@ -86,6 +86,15 @@ class Domino
       require_selector! { find_by_attributes!(attributes) }
     end
 
+    # Returns collection of Dominos for capybara node matching all attributes.
+    def where(attributes)
+      require_selector! do
+        select do |node|
+          node.attributes.merge(attributes) == node.attributes
+        end
+      end
+    end
+
     # Define the selector for this Domino
     #
     #   module Dom

--- a/test/domino_test.rb
+++ b/test/domino_test.rb
@@ -193,4 +193,22 @@ class DominoTest < MiniTest::Unit::TestCase
       Dom::Person.find_by!(foo: "bar")
     end
   end
+
+  def test_where_with_single_attribute
+    assert_equal %w(Bob Charlie), Dom::Person.where(favorite_color: "Red").map(&:name)
+  end
+
+  def test_where_with_multiple_attributes
+    assert_equal %w(Alice), Dom::Person.where(age: 23, favorite_color: 'Blue').map(&:name)
+  end
+
+  def test_where_without_match
+    assert_equal [], Dom::Person.where(favorite_color: "Yellow")
+  end
+
+  def test_where_without_selector
+    assert_raises Domino::Error do
+      Dom::NoSelector.where(foo: "bar")
+    end
+  end
 end


### PR DESCRIPTION
This adds a Rails-style `find_by` method that accepts a hash of 1 or more attribute/text pairs to match nodes against. A `find_by!` method was also added that raises a `Capybara::ElementNotFound` exception when no match is found.
