### PR TITLE
Improve performance of `find_by` and `find_by!`

### DIFF
--- a/lib/domino.rb
+++ b/lib/domino.rb
@@ -85,7 +85,9 @@ class Domino
     # Returns collection of Dominos for capybara node matching all attributes.
     def where(attributes)
       select do |node|
-        attributes.to_set.subset?(node.attributes.to_set)
+        attributes.all? do |key, value|
+          node.send(key) == value if node.respond_to?(key)
+        end
       end
     end
 


### PR DESCRIPTION
`find_by` unnecessarily fetches all attributes of a node.  This becomes
especially problematic during certain tests utilizing Capybara, since it
triggers the wait timeout for each missing attribute in the node.

This change alters the logic so that rather then fetching all of the node's
attributes, we only fetch the attributes that we need to test against. It
improves performance and potentially shaves a lot of time off of test
suites.