### PR TITLE
Yield node to block provided by attribute/field reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,27 @@ end
 Provide your custom class using the `:as` option when defining your field,
 as shown in the example above.
 
+### Accessing the Attribute/Field Node
+
+The named accessor method for any field or attribute will yield the Capybara
+node of the attribute if you pass a block. You can use this to check
+certain properties of the node without having to break out of your Dominos.
+
+**Example:** Checking available options in a select field
+
+```ruby
+person = Dom::PersonForm.find!
+expected_options = ["- Select a Color -", "Red", "Blue", "Green"]
+assert_equal expected_options, person.favorite_color { |n| n.all('option').map(&:text) }
+```
+
+**Example:** Checking the tag of the node containing the attribute value
+
+```ruby
+person = Dom::Person.find_by!(uuid: "e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f")
+assert_equal "h2", person.name { |n| n.tag_name }
+```
+
 ## Integration with capybara
 
 Domino uses capybara internally to search html for nodes and

--- a/lib/domino.rb
+++ b/lib/domino.rb
@@ -138,8 +138,12 @@ class Domino
 
       attribute_definitions[attribute] = Attribute.new(attribute, selector, &callback)
 
-      define_method :"#{attribute}" do
-        self.class.attribute_definitions[attribute].value(node)
+      define_method :"#{attribute}" do |&block|
+        if block.is_a?(Proc)
+          block.call(self.class.attribute_definitions[attribute].element(node))
+        else
+          self.class.attribute_definitions[attribute].value(node)
+        end
       end
 
       define_singleton_method :"find_by_#{attribute}" do |value|

--- a/lib/domino/attribute.rb
+++ b/lib/domino/attribute.rb
@@ -34,6 +34,14 @@ class Domino::Attribute
     value === value(node)
   end
 
+  def element(node)
+    if combinator?
+      node
+    else
+      node.find(selector)
+    end
+  end
+
   private
 
   def combinator?

--- a/lib/domino/form.rb
+++ b/lib/domino/form.rb
@@ -39,8 +39,12 @@ class Domino::Form < Domino
 
     field_definitions[attribute] = field_class.new(attribute, locator, options, &callback)
 
-    define_method :"#{attribute}" do
-      self.class.field_definitions[attribute].value(node)
+    define_method :"#{attribute}" do |&block|
+      if block.is_a?(Proc)
+        block.call(self.class.field_definitions[attribute].field(node))
+      else
+        self.class.field_definitions[attribute].value(node)
+      end
     end
 
     define_method :"#{attribute}=" do |value|

--- a/lib/domino/form/field.rb
+++ b/lib/domino/form/field.rb
@@ -12,8 +12,7 @@ class Domino::Form::Field
   # Delete any options for your field type that shouldn't be passed to
   # the field locator.
   # Default: noop
-  def extract_field_options
-  end
+  def extract_field_options; end
 
   # Convert the value from `#read` via callback if provided.
   def value(node)

--- a/lib/domino/form/select_field.rb
+++ b/lib/domino/form/select_field.rb
@@ -2,7 +2,7 @@ class Domino::Form::SelectField < Domino::Form::Field
   # Returns the set of selected options that can be processed in the callback.
   def read(node)
     s = field(node)
-    selected = s.all("option[selected]")
+    selected = s.all('option[selected]')
     s.multiple? ? selected : selected.first
   end
 

--- a/test/domino_form_test.rb
+++ b/test/domino_form_test.rb
@@ -187,14 +187,14 @@ class DominoFormTest < Minitest::Test
   end
 
   def test_static_create_with_no_matches
-    visit "/"
+    visit '/'
     assert_raises Capybara::ElementNotFound do
       Dom::PersonForm.create name: 'Marie', last_name: 'Curie'
     end
   end
 
   def test_static_update_with_no_matches
-    visit "/"
+    visit '/'
     assert_raises Capybara::ElementNotFound do
       Dom::PersonForm.update name: 'Marie', last_name: 'Curie'
     end
@@ -202,5 +202,17 @@ class DominoFormTest < Minitest::Test
 
   def test_supports_normal_attributes
     assert_equal({ action: '/people/23', submit_method: 'post' }, Dom::PersonForm.find!.attributes)
+  end
+
+  def test_named_field_method_yields_node
+    person = Dom::PersonForm.find!
+    name_field_node = page.find_field('First Name')
+    assert_equal(name_field_node, person.name { |node| node })
+    person.name { |node| node }
+  end
+
+  def test_named_field_yield_usefulness
+    person = Dom::PersonForm.find!
+    assert_equal ['- Select a Color -', 'Red', 'Blue', 'Green'], person.favorite_color { |n| n.all('option').map(&:text) }
   end
 end

--- a/test/domino_test.rb
+++ b/test/domino_test.rb
@@ -188,4 +188,21 @@ class DominoTest < Minitest::Test
       Dom::NoSelector.where(foo: 'bar')
     end
   end
+
+  def test_named_field_method_yields_node
+    person = Dom::Person.find_by!(uuid: 'e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f')
+    name_node = page.find(".person[data-uuid='e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f'] .name")
+    assert_equal(name_node, person.name { |node| node })
+  end
+
+  def test_named_field_method_yields_node_when_combinator
+    person = Dom::Person.find_by!(uuid: 'e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f')
+    uuid_node = page.find(".person[data-uuid='e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f']")
+    assert_equal(uuid_node, person.uuid { |node| node })
+  end
+
+  def test_named_field_yield_usefulness
+    person = Dom::Person.find_by!(uuid: 'e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f')
+    assert_equal 'h2', person.name(&:tag_name)
+  end
 end

--- a/test/test_application.rb
+++ b/test/test_application.rb
@@ -22,7 +22,7 @@ class TestApplication
       edit params
     when '/people/23'
       params = Rack::Utils.parse_nested_query(env.fetch('rack.input').read)
-      edit params.merge(flash: "Person updated successfully.")
+      edit params.merge(flash: 'Person updated successfully.')
     end
   end
 


### PR DESCRIPTION
@ngauthier You asked for it 😼 

This patch allows a user to access the underlying node of an attribute
or field by passing a block.

This would be especially useful for checking, for instance, if a
field is disabled or readonly, or if you need to check some other
property about the element that holds the attribute.

Examples:

Checking available options of a select field:

```ruby
person = Dom::PersonForm.find!
expected_options = ["- Select a Color -", "Red", "Blue", "Green"]
assert_equal expected_options, person.favorite_color { |n| n.all('option').map(&:text) }
```

Checking that the name element is a header tag:

```ruby
person = Dom::Person.find_by!(uuid: "e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f")
assert_equal "h2", person.name { |n| n.tag_name }
```

I've thought about other ways of including accessors for this, but
this seemed pretty fluent, and allows you to map the attribute's
containing element to whatever attributes you might want. Alternatively,
I'd recommend adding more methods, like `<attribute>_node`, but
this way felt more fun to me. Also, you can do assertions within
the attribute's block this way.