### PR TITLE
Allow using `find_by_<attribute>` with predicate yielding node

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Now in your integration test you can use some of Domino's methods:
 assert_equal 4, Dom::Post.count
 refute_nil Dom::Post.find_by_title('First Post')
 
+# Find by attribute yields the node when using a block.
+assert_equal Dom::Post.find_by_title { |node| node.text == "First Post" && node.tag_name == 'p' }
+
 # Multiple attributes, returns first match if any
 refute_nil Dom::Post.find_by(title: 'First Post', author: 'Jane Doe')
 

--- a/lib/domino.rb
+++ b/lib/domino.rb
@@ -146,8 +146,8 @@ class Domino
         end
       end
 
-      define_singleton_method :"find_by_#{attribute}" do |value|
-        find_by_attribute(attribute, value)
+      define_singleton_method :"find_by_#{attribute}" do |value = nil, &predicate|
+        find_by_attribute(attribute, value, &predicate)
       end
     end
 
@@ -160,9 +160,9 @@ class Domino
     end
 
     # Internal method for finding nodes by a selector
-    def find_by_attribute(attribute, value)
+    def find_by_attribute(attribute, value = nil, &predicate)
       detect do |domino|
-        attribute_definitions[attribute].match_value?(domino.node, value)
+        attribute_definitions[attribute].match_value?(domino.node, value, &predicate)
       end
     end
 

--- a/lib/domino/attribute.rb
+++ b/lib/domino/attribute.rb
@@ -9,11 +9,14 @@ class Domino::Attribute
 
   def value(node)
     val = value_before_typecast(node)
+    convert(val)
+  end
 
-    if val && callback.is_a?(Proc)
-      callback.call(val)
+  def convert(value)
+    if value && callback.is_a?(Proc)
+      callback.call(value)
     else
-      val
+      value
     end
   end
 
@@ -30,8 +33,14 @@ class Domino::Attribute
     nil
   end
 
-  def match_value?(node, value)
-    value === value(node)
+  def match_value?(node, value = nil, &predicate)
+    if predicate.is_a?(Proc)
+      predicate.call(element(node))
+    else
+      node_value = value(node)
+      test_value = convert(value) rescue value
+      test_value === node_value
+    end
   end
 
   def element(node)

--- a/test/domino_test.rb
+++ b/test/domino_test.rb
@@ -205,4 +205,19 @@ class DominoTest < Minitest::Test
     person = Dom::Person.find_by!(uuid: 'e94bb2d3-71d2-4efb-abd4-ebc0cb58d19f')
     assert_equal 'h2', person.name(&:tag_name)
   end
+
+  def test_find_by_with_unconverted_value_for_callback_computed_attribute
+    person = Dom::Person.find_by!(uuid: '05bf319e-8d6a-43c2-be37-2dad8ddbe5af')
+    assert_equal person.node, Dom::Person.find_by_age('52').node
+  end
+
+  def test_find_by_with_converted_value_for_callback_computed_attribute
+    person = Dom::Person.find_by!(uuid: '05bf319e-8d6a-43c2-be37-2dad8ddbe5af')
+    assert_equal person.node, Dom::Person.find_by_age(52).node
+  end
+
+  def test_find_by_with_converted_value_for_callback_computed_attribute_with_regex
+    person = Dom::Person.find_by!(uuid: '05bf319e-8d6a-43c2-be37-2dad8ddbe5af')
+    assert_equal person.node, Dom::Person.find_by_age { |age_node| age_node.text =~ /5[29]/ && age_node.tag_name == 'p' }.node
+  end
 end


### PR DESCRIPTION
Similar to how you can now check things on the Capybara node, you
can also use `find_by_<attribute>` and pass a block instead of a
value. The block will yield the attribute's containing Capybara node
so that you can perform more complex searches that include checks
on the node itself.

Fixes #15.

We also attempt to convert the passed value using the attribute's
callback when doing a node lookup. So if your age attribute converts
using the callback `&:to_i`, you can still pass `find_by_age("23")`
and it will still match.